### PR TITLE
Fixed conflicting types error for 'mqtt_parse_msg_id'

### DIFF
--- a/include/libemqtt.h
+++ b/include/libemqtt.h
@@ -114,7 +114,7 @@ uint16_t mqtt_parse_rem_len(const uint8_t* buf);
  *
  * @retval message id
  */
-uint8_t mqtt_parse_msg_id(const uint8_t* buf);
+uint16_t mqtt_parse_msg_id(const uint8_t* buf);
 
 /** Parse a packet buffer for the publish topic.
  *


### PR DESCRIPTION
On line 81 defined as
`uint16_t mqtt_parse_msg_id(const uint8_t* buf)`
